### PR TITLE
Sign-in Failure + Sign-up Email Duplicate + Redirecting after Sign-up + Editing User Profile Duplicates

### DIFF
--- a/umbrella/templates/umbrella/googlemap.html
+++ b/umbrella/templates/umbrella/googlemap.html
@@ -29,6 +29,11 @@
                                 <a href="#" data-toggle="modal" data-target="#register" class="alert-link">{{ message }}
                                 </a>
                             {% endif %}
+                            {% if "edit" in message.tags %}
+                                <strong>Oh snap! </strong>
+                                <a href="#" data-toggle="modal" data-target="#viewProfile" class="alert-link">{{ message }}
+                                </a>
+                            {% endif %}
                         {% endfor %}
                     </div>
 

--- a/umbrella/views.py
+++ b/umbrella/views.py
@@ -12,8 +12,23 @@ def update_user_profile(request):
 
     if request.method == 'POST':
         actual_user = request.user
+
+        old_username = actual_user.username
+        old_email    = actual_user.email
+
         actual_user.username = request.POST['display_name']
         actual_user.email = request.POST['email']
+
+        if User.objects.filter(username=actual_user.username).exists() and actual_user.username != old_username:
+            messages.add_message(request, messages.ERROR, "That display name is taken already! Try something else.",
+                                 "edit")
+            return HttpResponseRedirect(reverse('umbrella:googlemap'))
+
+        if User.objects.filter(email=actual_user.email).exists()and actual_user.email != old_email:
+            messages.add_message(request, messages.ERROR, "That email address is taken already! Try something else.",
+                                 "edit")
+            return HttpResponseRedirect(reverse('umbrella:googlemap'))
+
         actual_user.save()
 
         pass
@@ -79,6 +94,10 @@ def create_user(request):
     user_name = request.POST['display_name']
     user_pass = request.POST['password']
     user_mail = request.POST['email']
+
+    if User.objects.filter(username=user_name).exists():
+        messages.add_message(request, messages.ERROR, "That display name is taken already! Try something else.", "create")
+        return HttpResponseRedirect(reverse('umbrella:googlemap'))
 
     if User.objects.filter(email=user_mail).exists():
         messages.add_message(request, messages.ERROR, "That email address is taken already! Try something else.", "create")


### PR DESCRIPTION
The following can be found in this branch:
- If user inputs bad credentials when logging in, a redirect to the googlemap.html page is performed with a message from the django.contrib.messages module;
- If the user attempts to sign up with an email address that is already associated with an account, we redirect to googlemap.html with an infromative message. Similarly, a check for duplicate display name is put;
- After the user registers, they are sent to googlemap.html as a logged-in user;
- Checks to avoid duplicate display names and emails upon user editing their profile.
